### PR TITLE
Fix cast-qual warning in ketopt.h

### DIFF
--- a/ketopt.h
+++ b/ketopt.h
@@ -96,7 +96,7 @@ static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *
 		const char *p;
 		if (s->pos == 0) s->pos = 1;
 		opt = s->opt = argv[s->i][s->pos++];
-		p = strchr((char*)ostr, opt);
+		p = strchr((const char*)ostr, opt);
 		if (p == 0) {
 			opt = '?'; /* unknown option */
 		} else if (p[1] == ':') {


### PR DESCRIPTION
```
klib/ketopt.h:99:14: warning: cast discards ‘const’ qualifier from pointer target type [-Wcast-qual]
   99 |   p = strchr((char*)ostr, opt);
      |              ^
```